### PR TITLE
ONEMPERS-362 accept friendly name

### DIFF
--- a/server/gdial-ssdp.h
+++ b/server/gdial-ssdp.h
@@ -25,7 +25,7 @@
 
 G_BEGIN_DECLS
 
-int gdial_ssdp_init(SoupServer *server, GDialOptions *options);
+int gdial_ssdp_init(SoupServer *server, GMutex *friendlyname_mutex, GDialOptions *options, gboolean *friendlyname_changed);
 int gdial_ssdp_term();
 int gdial_ssdp_set_available(gboolean activationStatus);
 G_END_DECLS

--- a/server/include/gdial-plat-app.h
+++ b/server/include/gdial-plat-app.h
@@ -30,7 +30,9 @@ void gdial_plat_term();
 
 typedef void * gdial_async_handler_t;
 typedef void (*gdial_plat_activation_cb)(gboolean);
+typedef void (*gdial_plat_friendlyname_cb)(const char*);
 void gdail_plat_register_activation_cb(gdial_plat_activation_cb cb);
+void gdail_plat_register_friendlyname_cb(gdial_plat_friendlyname_cb cb);
 
 GDialAppError gdial_plat_application_start(const gchar *app_name, const gchar *payload, const gchar *query, const gchar *additional_data_url, gint *instance_id);
 GDialAppError gdial_plat_application_hide(const gchar *app_name, gint instance_id);

--- a/server/plat/gdial-plat-app.c
+++ b/server/plat/gdial-plat-app.c
@@ -133,6 +133,11 @@ void gdail_plat_register_activation_cb(gdial_plat_activation_cb cb)
   rtdail_register_activation_cb((rtdial_activation_cb)cb);
 }
 
+void gdial_plat_register_friendlyname_cb(gdial_plat_friendlyname_cb cb)
+{
+  rtdial_register_friendly_name_cb((rtdial_friendlyname_cb)cb);
+}
+
 gint gdial_plat_init(GMainContext *main_context) {
   g_return_val_if_fail(main_context != NULL, GDIAL_APP_ERROR_INTERNAL);
   g_return_val_if_fail((g_main_context_ == NULL || g_main_context_ == main_context), GDIAL_APP_ERROR_INTERNAL);

--- a/server/plat/rtcast.hpp
+++ b/server/plat/rtcast.hpp
@@ -57,8 +57,10 @@ public:
 
     rtMethod1ArgAndNoReturn("onApplicationStateChanged", applicationStateChanged, rtObjectRef);
     rtMethod1ArgAndNoReturn("onActivationChanged", activationChanged, rtObjectRef);
+    rtMethod1ArgAndNoReturn("onFriendlyNameChanged", friendlyNameChanged, rtObjectRef);
     virtual rtError applicationStateChanged(const rtObjectRef& params){ printf("applicationStateChanged rtCastRemoteObject");}
     virtual rtError activationChanged (const rtObjectRef& params){ printf("activationChanged rtCastRemoteObject");}
+    virtual rtError friendlyNameChanged (const rtObjectRef& params){ printf("friendlyNameChanged rtCastRemoteObject");}
 
   /*
     * rtCast implementation should emit these events:

--- a/server/plat/rtdial.cpp
+++ b/server/plat/rtdial.cpp
@@ -35,6 +35,7 @@ static int INIT_COMPLETED = 0;
 //cache
 rtAppStatusCache* AppCache;
 static rtdial_activation_cb g_activation_cb = NULL;
+static rtdial_friendlyname_cb g_friendlyname_cb = NULL;
 
 #define XCAST_SYSTEM_OBJECT_SERVICE_NAME "com.comcast.xcast_system"
 #define RTDIAL_CONNECT_TO_XCAST_SYSTEM_TIMEOUT_MS 500
@@ -83,6 +84,18 @@ public:
                 g_activation_cb(0);
             }
         }
+        return RT_OK;
+    }
+
+    rtError friendlyNameChanged(const rtObjectRef& params) {
+        rtString friendly_name;
+        params.get("friendlyname", friendly_name);
+        printf("RTDIAL: rtDialCastRemoteObject::friendlyNameChanged name: %s \n", friendly_name.cString());
+        if(g_friendlyname_cb)
+        {
+            g_friendlyname_cb(friendly_name.cString());
+        }
+
         return RT_OK;
     }
 
@@ -152,6 +165,7 @@ private:
 rtDefineObject(rtCastRemoteObject, rtAbstractService);
 rtDefineMethod(rtCastRemoteObject, applicationStateChanged);
 rtDefineMethod(rtCastRemoteObject, activationChanged);
+rtDefineMethod(rtCastRemoteObject, friendlyNameChanged);
 
 rtDialCastRemoteObject* DialObj;
 
@@ -214,6 +228,11 @@ static GSource *attachRtRemoteSource()
 void rtdail_register_activation_cb(rtdial_activation_cb cb)
 {
   g_activation_cb = cb;
+}
+
+void rtdial_register_friendly_name_cb(rtdial_friendlyname_cb cb)
+{
+  g_friendlyname_cb = cb;
 }
 
 static void rtdial_connect_to_xcast_system();

--- a/server/plat/rtdial.hpp
+++ b/server/plat/rtdial.hpp
@@ -29,7 +29,9 @@ extern "C" {
 bool rtdial_init(GMainContext *context);
 void rtdial_term();
 typedef void (*rtdial_activation_cb)(bool);
+typedef void (*rtdial_friendlyname_cb)(const char*);
 void rtdail_register_activation_cb(rtdial_activation_cb cb);
+void rtdial_register_friendly_name_cb(rtdial_friendlyname_cb cb);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This commit adds implements the possibility to change a friendly name.
The friendly name was passed from XCast but xdial did not use it.