### PR TITLE
ONEMPERS-624: xdial delayed rest responses

### DIFF
--- a/server/gdial-rest.h
+++ b/server/gdial-rest.h
@@ -50,6 +50,9 @@ GDIAL_STATIC gboolean gdial_rest_server_is_allowed_origin(GDialRestServer *self,
 GDIAL_STATIC gchar *gdial_rest_server_new_additional_data_url(guint listening_port, const gchar *app_name, gboolean encode);
 GDIAL_STATIC GDialAppRegistry *gdial_rest_server_find_app_registry(GDialRestServer *self, const gchar *app_name);
 
+GThreadPool * gdial_rest_http_server_create_app_handler_thread_pool();
+void gdial_rest_http_server_destroy_app_handler_thread_pool(GThreadPool * pool);
+
 G_END_DECLS
 
 #endif

--- a/server/include/gdial-plat-app.h
+++ b/server/include/gdial-plat-app.h
@@ -39,6 +39,7 @@ GDialAppError gdial_plat_application_hide(const gchar *app_name, gint instance_i
 GDialAppError gdial_plat_application_resume(const gchar *app_name, gint instance_id);
 GDialAppError gdial_plat_application_stop(const gchar *app_name, gint instance_id);
 GDialAppError gdial_plat_application_state(const gchar *app_name, gint instance_id, GDialAppState *state);
+GDialAppError gdial_plat_application_state_wait(const gchar *app_name, gint instance_id, GDialAppState state, unsigned int tiemout_ms);
 
 void * gdial_plat_application_start_async(const gchar *app_name, const gchar *payload, const gchar *query, const gchar *additional_data_url, void *user_data);
 void * gdial_plat_application_state_async(const gchar *app_name, gint instance_id, void *user_data);

--- a/server/main.c
+++ b/server/main.c
@@ -191,6 +191,7 @@ int main(int argc, char *argv[]) {
          break;
      }
   }
+  GThreadPool * thread_pool = gdial_rest_http_server_create_app_handler_thread_pool();
   gdial_plat_init(g_main_context_default());
 
   gdial_plat_register_activation_cb(server_activation_handler);
@@ -208,6 +209,7 @@ int main(int argc, char *argv[]) {
   if (!success) {
     g_printerr("%s\r\n", error->message);
     g_error_free(error);
+    gdial_rest_http_server_destroy_app_handler_thread_pool(thread_pool);
     return EXIT_FAILURE;
   }
   else {
@@ -217,6 +219,7 @@ int main(int argc, char *argv[]) {
     if (!success) {
       g_printerr("%s\r\n", error->message);
       g_error_free(error);
+      gdial_rest_http_server_destroy_app_handler_thread_pool(thread_pool);
       return EXIT_FAILURE;
     }
     else {
@@ -224,6 +227,7 @@ int main(int argc, char *argv[]) {
       if (!success) {
         g_printerr("%s\r\n", error->message);
         g_error_free(error);
+        gdial_rest_http_server_destroy_app_handler_thread_pool(thread_pool);
         return EXIT_FAILURE;
       }
     }
@@ -293,6 +297,7 @@ int main(int argc, char *argv[]) {
    */
   loop_ = g_main_loop_new (NULL, TRUE);
   g_main_loop_run (loop_);
+  gdial_rest_http_server_destroy_app_handler_thread_pool(thread_pool);
   for (int i = 0; i < sizeof(servers)/sizeof(servers[0]); i++) {
     soup_server_disconnect(servers[i]);
     g_object_unref(servers[i]);

--- a/server/plat/gdial-os-app.h
+++ b/server/plat/gdial-os-app.h
@@ -32,6 +32,7 @@ int gdial_os_application_hide(const char *app_name, int instance_id);
 int gdial_os_application_resume(const char *app_name, int instance_id);
 int gdial_os_application_stop(const char *app_name, int instance_id);
 int gdial_os_application_state(const char *app_name, int instance_id, GDialAppState *state);
+int gdial_os_application_state_wait(const char *app_name, int instance_id, GDialAppState state, unsigned int timeout_ms);
 int gdial_os_system_app(GHashTable *query);
 
 #ifdef __cplusplus

--- a/server/plat/gdial-plat-app.c
+++ b/server/plat/gdial-plat-app.c
@@ -224,6 +224,14 @@ void *gdial_plat_application_stop_async(const gchar *app_name, gint instance_id,
   return app_async_context;
 }
 
+GDialAppError gdial_plat_application_state_wait(const gchar *app_name, gint instance_id, GDialAppState state, unsigned int tiemout_ms) {
+  g_print("GDIAL : Inside gdial_plat_application_state_wait\n");
+  g_return_val_if_fail(app_name != NULL, GDIAL_APP_ERROR_BAD_REQUEST);
+  g_return_val_if_fail(instance_id != GDIAL_APP_INSTANCE_NONE, GDIAL_APP_ERROR_BAD_REQUEST);
+
+  return gdial_os_application_state_wait(app_name, instance_id, state, tiemout_ms) ? GDIAL_APP_ERROR_NONE : GDIAL_APP_ERROR_INTERNAL;
+}
+
 GDialAppError gdial_plat_application_state(const gchar *app_name, gint instance_id, GDialAppState *state) {
   g_print("GDIAL : Inside gdial_plat_application_state\n");
   g_return_val_if_fail(app_name != NULL, GDIAL_APP_ERROR_BAD_REQUEST);

--- a/server/plat/rtcache.hpp
+++ b/server/plat/rtcache.hpp
@@ -27,7 +27,8 @@
 #include <iostream>
 #include <chrono>
 #include <stdbool.h>
-
+#include <mutex>
+#include <condition_variable>
 using namespace std;
 
 class rtAppStatusCache : public rtObject
@@ -35,16 +36,16 @@ class rtAppStatusCache : public rtObject
 public:
     rtAppStatusCache(rtRemoteEnvironment* env) {ObjectCache = new rtRemoteObjectCache(env);};
     ~rtAppStatusCache() {delete(ObjectCache); };
-    std::string getAppCacheId(const char *app_name);
-    void setAppCacheId(const char *app_name,std::string id);
     rtError UpdateAppStatusCache(rtValue app_status);
     const char * SearchAppStatusInCache(const char *app_name);
-    bool doIdExist(std::string id);
-
+    bool WaitForAppState(const char * app_name, const char * desired_state, unsigned int timeout_ms);
 private:
+    bool doIdExist(std::string id);
+    const char * SearchAppStatusInCacheLocked(const char *app_name);
     rtRemoteObjectCache* ObjectCache;
-    static std::string Netflix_AppCacheId;
-    static std::string Youtube_AppCacheId;
+    std::mutex CacheMutex;
+    std::condition_variable CacheCondVar;
+    bool CacheModified = false;
 };
 
 #endif

--- a/server/plat/rtdial.cpp
+++ b/server/plat/rtdial.cpp
@@ -471,6 +471,18 @@ int gdial_os_application_resume(const char *app_name, int instance_id) {
     return GDIAL_APP_ERROR_NONE;
 }
 
+int gdial_os_application_state_wait(const char *app_name, int instance_id, GDialAppState state, unsigned int timeout_ms) {
+    const char * str_state = state == GDIAL_APP_STATE_RUNNING ? "running" :
+                              state == GDIAL_APP_STATE_HIDE ? "suspended" :
+                              state == GDIAL_APP_STATE_STOPPED ? "stopped" : NULL;
+    if (str_state == NULL) {
+        printf("RTDIAL %s: unexpected state: %d\n", __FUNCTION__, state);
+        return 0;
+    } else {
+        return AppCache->WaitForAppState(app_name, str_state, timeout_ms) ? 1 : 0;
+    }
+}
+
 int gdial_os_application_state(const char *app_name, int instance_id, GDialAppState *state) {
     printf("RTDIAL gdial_os_application_state: App = %s \n",app_name);
     const char* State = AppCache->SearchAppStatusInCache(app_name);


### PR DESCRIPTION
Responses related to application state changes waits with timeout for "onApplicationStateChanged" notifications.

The following reuqest handled in that way:

(1) create/start/show applcation: curl -v -X POST  http://10.42.0.162:56889/apps/AppName:
* wait for "applicationStateChanged" with "running" state for 35 seconds (APPLICATION_STATE_CHANGE_START_TIMEOUT)

(2) hide application: curl -v -X POST  http://10.42.0.162:56889/apps/AppName/run/hide:
* wait for "applicationStateChanged" with "suspended" state for 35 seconds (APPLICATION_STATE_CHANGE_HIDE_TIMEOUT)
* application should already be created to start waiting

(3) stop application: curl -v -X DELETE  http://10.42.0.162:56889/apps/AppName/run/:
* wait for "applicationStateChanged" with "stopped" state for 35 seconds (APPLICATION_STATE_CHANGE_STOP_TIMEOUT)
* application should already be created to start waiting

Additional changes (rtcache):
* access method synchronization + signalization of state change via condvar
* getAppCacheId removed - each application has now unique entry (not only YouTube/Netflix)
* WaitForAppState introduced - used in rest responses delayed implementation