### PR TITLE
OMWAPPI-1142 fix xdial warning

### DIFF
--- a/server/gdial-rest.c
+++ b/server/gdial-rest.c
@@ -256,7 +256,7 @@ GDIAL_STATIC gboolean gdial_rest_server_is_allowed_origin(GDialRestServer *self,
   const gchar *uri_scheme = origin_uri ? soup_uri_get_scheme(origin_uri) : NULL;
 
   if (origin_uri && uri_scheme &&
-    (uri_scheme == "package" || uri_scheme == SOUP_URI_SCHEME_HTTPS )) {
+    (!g_strcmp0(uri_scheme, "package") || !g_strcmp0(uri_scheme, SOUP_URI_SCHEME_HTTPS))) {
     GDialAppRegistry *app_registry = gdial_rest_server_find_app_registry(self, app_name);
     if (app_registry) {
       is_allowed = gdial_app_registry_is_allowed_origin (app_registry, header_origin);
@@ -567,7 +567,7 @@ static void gdial_rest_server_handle_GET_app(GDialRestServer *gdial_rest_server,
   GET_APP_response_builder_destroy(builder);
   #else
   int response_len = 0;
-  gpointer allow_stop = g_hash_table_lookup(app_registry->properties,"allowStop");
+  gchar *allow_stop = (gchar*)g_hash_table_lookup(app_registry->properties,"allowStop");
   if(allow_stop == NULL) {
     allow_stop = "false";
   }
@@ -633,7 +633,7 @@ static void gdial_rest_server_handle_POST_dial_data(GDialRestServer *gdial_rest_
   soup_message_set_status(msg, SOUP_STATUS_OK);
 }
 
-static void gdial_rest_http_server_system_callback(SoupServer *server,
+inline static void gdial_rest_http_server_system_callback(SoupServer *server,
             SoupMessage *msg, const gchar *path, GHashTable *query,
             SoupClientContext  *client, gpointer user_data) {
 
@@ -1059,7 +1059,7 @@ GDialRestServer *gdial_rest_server_new(SoupServer *rest_http_server,SoupServer *
   return object;
 }
 
-gboolean gdial_rest_server_register_app(GDialRestServer *self, const gchar *app_name, const GList *app_prefixes, const GHashTable *properties, gboolean is_singleton, gboolean use_additional_data, const GList *allowed_origins) {
+gboolean gdial_rest_server_register_app(GDialRestServer *self, const gchar *app_name, const GList *app_prefixes, GHashTable *properties, gboolean is_singleton, gboolean use_additional_data, const GList *allowed_origins) {
 
   g_return_val_if_fail(self != NULL && app_name != NULL, FALSE);
   /*

--- a/server/gdial-rest.h
+++ b/server/gdial-rest.h
@@ -40,7 +40,7 @@ struct _GDialRestServer {
 };
 
 GDialRestServer *gdial_rest_server_new(SoupServer *rest_http_server,SoupServer *local_rest_http_server, gchar *random_uuid);
-gboolean gdial_rest_server_register_app(GDialRestServer *self, const gchar *app_name, const GList *app_prefixes, const GHashTable *properties, gboolean is_singleton, gboolean use_additional_data, const GList *allowed_origin);
+gboolean gdial_rest_server_register_app(GDialRestServer *self, const gchar *app_name, const GList *app_prefixes, GHashTable *properties, gboolean is_singleton, gboolean use_additional_data, const GList *allowed_origin);
 gboolean gdial_rest_server_register_app_registry(GDialRestServer *self, GDialAppRegistry *app_registry);
 gboolean gdial_rest_server_is_app_registered(GDialRestServer *self, const gchar *app_name);
 gboolean gdial_rest_server_unregister_app(GDialRestServer *self, const gchar *app_name);

--- a/server/gdial-ssdp.c
+++ b/server/gdial-ssdp.c
@@ -128,7 +128,7 @@ void gdial_ssdp_networkstandbymode_handler(const bool nwstandby)
         gssdp_client_remove_header(ssdp_client_, "WAKEUP");
      }
   }
-  return 0;
+  return;
 }
 
 int gdial_ssdp_new(SoupServer *ssdp_http_server, GDialOptions *options, const gchar *random_uuid) {

--- a/server/include/gdial_app_registry.h
+++ b/server/include/gdial_app_registry.h
@@ -43,7 +43,7 @@ typedef struct _GDialAppRegistry {
 
 void gdial_app_regstry_dispose (GDialAppRegistry *app_registry);
 gboolean gdial_app_registry_is_allowed_origin(GDialAppRegistry *app_registry, const gchar *header_origin);
-GDialAppRegistry* gdial_app_registry_new (const gchar *app_name, const GList *app_prefixes, const GHashTable *properties, gboolean is_singleton, gboolean use_additional_data, const GList *allowed_origins);
+GDialAppRegistry* gdial_app_registry_new (const gchar *app_name, const GList *app_prefixes, GHashTable *properties, gboolean is_singleton, gboolean use_additional_data, const GList *allowed_origins);
 
 G_END_DECLS
 

--- a/server/plat/gdial-plat-dev.c
+++ b/server/plat/gdial-plat-dev.c
@@ -21,6 +21,8 @@
 #include "gdial-plat-dev.h"
 #include "libIBus.h"
 #include "pwrMgr.h"
+#include <stdio.h>
+#include <unistd.h>
 
 IARM_Bus_PWRMgr_PowerState_t m_powerstate = IARM_BUS_PWRMGR_POWERSTATE_STANDBY;
 static int m_sleeptime = 1;
@@ -45,7 +47,7 @@ void gdial_plat_dev_power_mode_change(const char *owner, IARM_EventId_t eventId,
       m_sleeptime = 1;
       if (m_is_restart_req) {
         //xdial restart to work in deepsleep wakeup
-        system("systemctl restart xdial.service");
+        printf("systemctl restart xdial.service result: %d\n", system("systemctl restart xdial.service"));
         m_is_restart_req = false;
       }
     }

--- a/server/plat/gdial_app_registry.c
+++ b/server/plat/gdial_app_registry.c
@@ -25,7 +25,7 @@
 #define GDIAL_STR_ENDS_WITH(s1, s2) ((s1 != NULL) && (s2 != NULL) && ((strlen(s2) == 0) || (g_str_has_suffix(s1, s2))))
 
 void gdial_app_regstry_dispose (GDialAppRegistry *app_registry) {
-  g_return_val_if_fail(app_registry != NULL, TRUE);
+  g_return_if_fail(app_registry != NULL);
   printf ("freeing app name:%s\n", app_registry->name);
   g_free(app_registry->name);
   g_list_free_full(app_registry->allowed_origins, g_free);
@@ -60,7 +60,7 @@ gboolean gdial_app_registry_is_allowed_origin(GDialAppRegistry *app_registry, co
   return is_allowed;
 }
 
-GDialAppRegistry* gdial_app_registry_new (const gchar *app_name, const GList *app_prefixes, const GHashTable *properties, gboolean is_singleton, gboolean use_additional_data, const GList *allowed_origins) {
+GDialAppRegistry* gdial_app_registry_new (const gchar *app_name, const GList *app_prefixes, GHashTable *properties, gboolean is_singleton, gboolean use_additional_data, const GList *allowed_origins) {
   g_return_val_if_fail(app_name != NULL, NULL);
   g_return_val_if_fail(is_singleton, NULL);
 
@@ -82,7 +82,7 @@ GDialAppRegistry* gdial_app_registry_new (const gchar *app_name, const GList *ap
     app_registry->properties = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
     g_hash_table_iter_init(&prop_iter, properties);
     while (g_hash_table_iter_next(&prop_iter, &key, &value)) {
-      g_print("inside register app properties key:%s value:%s\n",key, value);
+      g_print("inside register app properties key:%s value:%s\n",(gchar*)key, (gchar*)value);
       g_hash_table_insert(app_registry->properties,g_strdup(key),g_strdup(value));
     }
   }

--- a/server/plat/rtdial.cpp
+++ b/server/plat/rtdial.cpp
@@ -179,7 +179,7 @@ public:
 
            }
        }
-       int appListSize = g_list_length (gAppList);
+
        if( g_registerapps_cb ) {
            printf("RTDIAL: rtDialCastRemoteObject:: calling register_applications callback \n");
            g_registerapps_cb(gAppList);
@@ -217,7 +217,7 @@ public:
             {
                 g_activation_cb(0,friendlyName.cString());
             }
-            printf("RTDIAL: rtDialCastRemoteObject:: status: %s  g_activation_cb :%d \n",status.cString(), g_activation_cb);
+            printf("RTDIAL: rtDialCastRemoteObject:: status: %s  g_activation_cb :%p \n",status.cString(), g_activation_cb);
         }
         return RT_OK;
     }


### PR DESCRIPTION
This removes most of xdial warnings; remaining ones are either caused by libsoup/glib version discrepancies or strange redefinitions of 'EXTERNAL' in couple
wpeframework files