### PR TITLE
OMWAPPI-1360 introduce XDIAL_MAX_STATE_VALUE_AGE_MS

### DIFF
--- a/server/plat/rtcache.cpp
+++ b/server/plat/rtcache.cpp
@@ -60,6 +60,7 @@ void rtAppStatusCache :: setAppCacheId(const char *app_name,std::string id)
 
 rtError rtAppStatusCache::UpdateAppStatusCache(rtValue app_status)
 {
+     const auto now = std::chrono::steady_clock::now();
      printf("RTCACHE : %s\n",__FUNCTION__);
 
       rtError err;
@@ -79,6 +80,7 @@ rtError rtAppStatusCache::UpdateAppStatusCache(rtValue app_status)
       notifyStateChanged(App_name);
       if (err == RT_OK) {
           err = ObjectCache->markUnevictable(id, true);
+          last_updated[id] = now;
       }
       return err;
 }
@@ -132,4 +134,16 @@ bool rtAppStatusCache::doIdExist(std::string id)
     }
     printf("True\n");
     return true;
+}
+
+std::chrono::milliseconds rtAppStatusCache::getUpdateAge(const char *app_name)
+{
+     const auto now = std::chrono::steady_clock::now();
+     std::string id = getAppCacheId(app_name);
+     auto it = last_updated.find(id);
+     if (it != last_updated.end()) {
+          return std::chrono::duration_cast<std::chrono::milliseconds>(now - it->second);
+     } else {
+          return std::chrono::milliseconds::max();
+     }
 }

--- a/server/plat/rtcache.hpp
+++ b/server/plat/rtcache.hpp
@@ -53,6 +53,8 @@ public:
     StateChangedCallbackHandle registerStateChangedCallback(StateChangedCallback callback);
     void unregisterStateChangedCallback(StateChangedCallbackHandle callbackId);
 
+    std::chrono::milliseconds getUpdateAge(const char *app_name);
+
 private:
 
     void notifyStateChanged(std::string& id);
@@ -63,6 +65,7 @@ private:
     StateChangedCallbackHandle next_handle = 0;
     std::map<StateChangedCallbackHandle, StateChangedCallback> state_changed_listeners;
     std::mutex state_changed_listeners_mutex;
+    std::map<std::string, std::chrono::steady_clock::time_point> last_updated;
 };
 
 #endif

--- a/server/plat/rtdial.cpp
+++ b/server/plat/rtdial.cpp
@@ -723,17 +723,25 @@ int gdial_os_application_state(const char *app_name, int instance_id, GDialAppSt
 }
 
 static bool await_application_state_update(const char *app_name) {
+    using namespace std::chrono;
     static int xdial_wait_for_rtremote_state_response_ms = -1;
     if (xdial_wait_for_rtremote_state_response_ms == -1) {
         const char* waitstr = getenv("XDIAL_WAIT_FOR_RTREMOTE_STATE_RESPONSE_MS");
         xdial_wait_for_rtremote_state_response_ms = waitstr ? atoi(waitstr) : 0;
     }
+    static auto xdial_max_state_value_age = milliseconds::max();
+    if (xdial_max_state_value_age == milliseconds::max()) {
+        const char* str = getenv("XDIAL_MAX_STATE_VALUE_AGE_MS");
+        xdial_max_state_value_age = milliseconds(str ? atoi(str) : 0);
+    }
+    // do not poll for the state update if currently held value is younger than XDIAL_MAX_STATE_VALUE_AGE_MS
+    if (xdial_max_state_value_age > milliseconds(0) && AppCache->getUpdateAge(app_name) < xdial_max_state_value_age) {
+        return false;
+    }
     std::atomic_bool updated {false};
     if (xdial_wait_for_rtremote_state_response_ms > 0) {
         // the cached status could be wrong; rtremote state update request has already been launched
         // so lets give it some time & report the updated value, if possible
-        using namespace std::chrono;
-
         auto handlerid = AppCache->registerStateChangedCallback([&](const std::string& application){
             if (application == app_name) {
                 updated = true;


### PR DESCRIPTION
To limit synchronous app state polling (that takes time), XDIAL_MAX_STATE_VALUE_AGE_MS env variable can be set to specify how long the last state update is still considered 'current'; until this time passes the last cached state is returned and the remote state is not queried.