### PR TITLE
ARRISAPP-483 GetNetworkStandbyMode unsupported

### DIFF
--- a/server/gdial-ssdp.c
+++ b/server/gdial-ssdp.c
@@ -164,11 +164,7 @@ int gdial_ssdp_new(SoupServer *ssdp_http_server, GDialOptions *options, const gc
   }
 
   gdail_plat_dev_register_nwstandbymode_cb(gdial_ssdp_networkstandbymode_handler);
-  //bool nwstandby_mode = gdial_plat_dev_get_nwstandby_mode();
-  bool nwstandby_mode = true;
-  // in our case implementation could return false here
-  // WAKEUP header would not be appended in such case
-  // observe fails on the following test: yts test <device id> "YouTube DIAL WakeUp Protocol"
+  bool nwstandby_mode = gdial_plat_dev_get_nwstandby_mode();
   g_print("gdial_ssdp_new nwstandby_mode:%d \n",nwstandby_mode);
   /*
    * setup configurable headers.

--- a/server/gdial-ssdp.c
+++ b/server/gdial-ssdp.c
@@ -163,9 +163,14 @@ int gdial_ssdp_new(SoupServer *ssdp_http_server, GDialOptions *options, const gc
       return EXIT_FAILURE;
   }
 
+#ifdef PWR_MGR_NW_STANDBY_MODE_SUPPORTED // ARRISAPP-483
   gdail_plat_dev_register_nwstandbymode_cb(gdial_ssdp_networkstandbymode_handler);
   bool nwstandby_mode = gdial_plat_dev_get_nwstandby_mode();
   g_print("gdial_ssdp_new nwstandby_mode:%d \n",nwstandby_mode);
+#else
+  bool nwstandby_mode = true;
+  g_print("gdial_ssdp_new: GetNetworkStandbyMode unsupported; nwstandby_mode assumed true\n");
+#endif
   /*
    * setup configurable headers.
    * header "SERVER" is populated by gssdp.

--- a/server/plat/gdial-plat-dev.c
+++ b/server/plat/gdial-plat-dev.c
@@ -60,6 +60,7 @@ void gdial_plat_dev_power_mode_change(const char *owner, IARM_EventId_t eventId,
   }
 }
 
+#ifdef PWR_MGR_NW_STANDBY_MODE_SUPPORTED
 void gdial_plat_dev_nwstandby_mode_change(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
 {
   if ((strcmp(owner, IARM_BUS_PWRMGR_NAME)  == 0) && ( eventId == IARM_BUS_PWRMGR_EVENT_NETWORK_STANDBYMODECHANGED )) {
@@ -68,6 +69,7 @@ void gdial_plat_dev_nwstandby_mode_change(const char *owner, IARM_EventId_t even
     printf("gdial_plat_dev_nwstandby_mode_change  new nwstandby_mode :%d \n ",param->data.bNetworkStandbyMode);
   }
 }
+#endif
 
 bool gdial_plat_dev_initialize() {
   IARM_Bus_Init("xdialserver");
@@ -75,7 +77,9 @@ bool gdial_plat_dev_initialize() {
   IARM_Result_t res;
 
   IARM_Bus_RegisterEventHandler(IARM_BUS_PWRMGR_NAME,IARM_BUS_PWRMGR_EVENT_MODECHANGED, gdial_plat_dev_power_mode_change);
+#ifdef PWR_MGR_NW_STANDBY_MODE_SUPPORTED
   IARM_Bus_RegisterEventHandler(IARM_BUS_PWRMGR_NAME,IARM_BUS_PWRMGR_EVENT_NETWORK_STANDBYMODECHANGED, gdial_plat_dev_nwstandby_mode_change);
+#endif
 
   IARM_Bus_PWRMgr_GetPowerState_Param_t param;
   res = IARM_Bus_Call(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_API_GetPowerState,

--- a/server/plat/gdial-plat-dev.c
+++ b/server/plat/gdial-plat-dev.c
@@ -62,11 +62,11 @@ void gdial_plat_dev_power_mode_change(const char *owner, IARM_EventId_t eventId,
 
 void gdial_plat_dev_nwstandby_mode_change(const char *owner, IARM_EventId_t eventId, void *data, size_t len)
 {
-/* TODO  if ((strcmp(owner, IARM_BUS_PWRMGR_NAME)  == 0) && ( eventId == IARM_BUS_PWRMGR_EVENT_NETWORK_STANDBYMODECHANGED )) {
+  if ((strcmp(owner, IARM_BUS_PWRMGR_NAME)  == 0) && ( eventId == IARM_BUS_PWRMGR_EVENT_NETWORK_STANDBYMODECHANGED )) {
     IARM_Bus_PWRMgr_EventData_t *param = (IARM_Bus_PWRMgr_EventData_t *)data;
     if(g_nwstandbymode_cb) g_nwstandbymode_cb(param->data.bNetworkStandbyMode);
     printf("gdial_plat_dev_nwstandby_mode_change  new nwstandby_mode :%d \n ",param->data.bNetworkStandbyMode);
-  } */
+  }
 }
 
 bool gdial_plat_dev_initialize() {
@@ -75,7 +75,7 @@ bool gdial_plat_dev_initialize() {
   IARM_Result_t res;
 
   IARM_Bus_RegisterEventHandler(IARM_BUS_PWRMGR_NAME,IARM_BUS_PWRMGR_EVENT_MODECHANGED, gdial_plat_dev_power_mode_change);
-  // TODO IARM_Bus_RegisterEventHandler(IARM_BUS_PWRMGR_NAME,IARM_BUS_PWRMGR_EVENT_NETWORK_STANDBYMODECHANGED, gdial_plat_dev_nwstandby_mode_change);
+  IARM_Bus_RegisterEventHandler(IARM_BUS_PWRMGR_NAME,IARM_BUS_PWRMGR_EVENT_NETWORK_STANDBYMODECHANGED, gdial_plat_dev_nwstandby_mode_change);
 
   IARM_Bus_PWRMgr_GetPowerState_Param_t param;
   res = IARM_Bus_Call(IARM_BUS_PWRMGR_NAME, IARM_BUS_PWRMGR_API_GetPowerState,


### PR DESCRIPTION
ARRISAPP-483 GetNetworkStandbyMode unsupported
  
  IARM_BUS_PWRMGR_API_GetNetworkStandbyMode iarm API is
  not implemented on our platform (in iarmmgrs this
  is guarded by ENABLE_LLAMA_PLATCO_SKY_XIONE define, which
  we don't have)
  Wrapping the usage in PWR_MGR_NW_STANDBY_MODE_SUPPORTED
  definition, that can be reenabled shall we need it in future.
