### PR TITLE
ARRISAPOL-3531: LGI specific customization

### DIFF
--- a/server/gdial-ssdp.c
+++ b/server/gdial-ssdp.c
@@ -177,6 +177,8 @@ int gdial_ssdp_new(SoupServer *ssdp_http_server, GDialOptions *options, const gc
    * header "EXT" is mandatory, set by gssdp
    * header "CACHE-CONTROL" is mandatory, set by gssdp, default 1800
    */
+  char * cpeId = getenv("CPE_ID");
+  if (cpeId) gssdp_client_set_server_id(ssdp_client, cpeId);
   gssdp_client_append_header(ssdp_client, "BOOTID.UPNP.ORG", "1");
   if(gdial_options_->feature_wolwake && nwstandby_mode) {
     g_print("WOL Wake feature is enabled");


### PR DESCRIPTION
SSDP responses in Server header should contain CPE ID only. Retrievied from CPE_ID env variable.

Veryfied by the following EB: https://jenkins.onemw.net/job/EngineeringBuild/31552/ with that injected change: https://gerrit.onemw.net/c/meta-lgi-om-common/+/120256/3/