### PR TITLE
ARRISAPOL-3531: remove usleeps that slow down rtt response

### DIFF
--- a/server/gdial-shield.c
+++ b/server/gdial-shield.c
@@ -87,7 +87,6 @@ static void soup_message_weak_ref_callback(gpointer user_data, GObject *obj) {
 static void server_request_started_callback (SoupServer *server, SoupMessage *msg,
     SoupClientContext *context, gpointer data) {
 
-  static const int throttle = GDIAL_THROTTLE_DELAY_US;
   DialShieldConnectionContext *conn_context = g_new(DialShieldConnectionContext, 1);
   guint read_timeout_source = g_timeout_add(2000, (GSourceFunc)soup_message_read_timeout_callback, msg);
   conn_context->read_gsocket = soup_client_context_get_gsocket(context);
@@ -96,7 +95,6 @@ static void server_request_started_callback (SoupServer *server, SoupMessage *ms
     pthread_self(), msg, read_timeout_source, g_socket_get_fd(conn_context->read_gsocket));
   g_hash_table_insert(active_conns_, msg, conn_context);
   g_object_weak_ref(G_OBJECT(msg), (GWeakNotify)soup_message_weak_ref_callback, msg);
-  usleep(throttle);
 }
 
 void gdial_shield_init(void) {

--- a/server/gdial-ssdp.c
+++ b/server/gdial-ssdp.c
@@ -111,7 +111,6 @@ static void ssdp_http_server_callback(SoupServer *server, SoupMessage *msg, cons
   soup_message_set_status(msg, SOUP_STATUS_OK);
   GDIAL_CHECK("Content-Type:text/xml");
   GDIAL_CHECK("Application-URL: exist");
-  usleep(GDIAL_RESPONSE_DELAY);
 }
 
 void gdial_ssdp_networkstandbymode_handler(const bool nwstandby)


### PR DESCRIPTION
we had in there 2*100 ms delay
Verification build: https://jenkins.onemw.net/job/EngineeringBuild/31569/ with the following inject: https://gerrit.onemw.net/c/meta-lgi-om-common/+/120299/2